### PR TITLE
Correct path in example that prevented the loading of babel

### DIFF
--- a/example/build.js
+++ b/example/build.js
@@ -1,6 +1,6 @@
 var path = require("path");
 
-var Interlock = require("..");
+var Interlock = require("../index.js");
 
 var ilk = new Interlock({
   root: __dirname,


### PR DESCRIPTION
Correct the path so that the example pulls in `./index.js` at the project root (recently moved.) Without this, the example loads `/lib/index.js` and fails on the ES6 import.