### PR TITLE
Feature/eslint

### DIFF
--- a/lib/compile/construct/index.js
+++ b/lib/compile/construct/index.js
@@ -152,7 +152,8 @@ const construct = {
     }
 
     if (opts.initialRequire) {
-      programBody = programBody.concat(construct.loadModuleWhenReady(opts.initialRequire, globalName));
+      programBody = programBody
+        .concat(construct.loadModuleWhenReady(opts.initialRequire, globalName));
     }
 
     return iifeTmpl({ body: programBody });

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -32,7 +32,8 @@ export const getModuleMaps = Pluggable.promise(function getModuleMaps (seedModul
     });
 }, { compileModules });
 
-export const getBundles = Pluggable.sync(function getBundles (bootstrappedBundles, moduleMapsPromise) {
+export const getBundles = Pluggable.sync(
+  function getBundles (bootstrappedBundles, moduleMapsPromise) {
   const explicitDedupedBundlesPromise = moduleMapsPromise
     .then(moduleMaps => this.dedupeExplicit(bootstrappedBundles, moduleMaps.byAbsPath));
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "lib/index.js",
   "scripts": {
+    "lint": "eslint --ignore-pattern example .",
     "test": "mocha spec/run.js"
   },
   "repository": {
@@ -30,7 +31,9 @@
     "source-map": "^0.4.2"
   },
   "devDependencies": {
+    "babel-eslint": "^3.1.26",
     "chai": "^2.3.0",
+    "eslint": "^0.24.1",
     "esquery": "^0.4.0",
     "mocha": "^2.2.4",
     "require-dir": "^0.3.0",


### PR DESCRIPTION
This PR does 3 things:

1. Add linting task to npm scripts
2. Pull linting dependencies into the project ('babel-eslint', 'eslint')
3. Correct the two Errors that cause linting to return an exit status of 1.