### PR TITLE
Add lib/index.js tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,11 +11,30 @@ import { entries } from "./util";
 import loadAst from "./compile/modules/load-ast";
 import compileModules from "./compile/modules/compile";
 
+/**
+ * @param   {Object}  options
+ * @param   {Array}   options.emit
+ * @param   {String}  options.root
+ * @param   {String}  options.context [optional]     Interlock's working directory
+ * @param   {String}  options.outputPath [optional]  An output directory
+ * @param   {Array}   options.extensions [optional]  A list of filetypes for Interlock to read
+ * @param   {String}  options.ns  [optional]         A custom prefix for generated bundles
+ */
 export default function Interlock (options) {
   const cwd = process.cwd();
 
-  if (!options.emit || !options.emit.length) {
+  if (!_.isArray(options.emit) || options.emit.length < 1) {
     throw new Error("Must define at least one bundle.");
+  }
+  if (!_.isString(options.root)) {
+    throw new Error("Must define a project root");
+  }
+
+  let ns;
+  try {
+    ns = require(path.join(options.root, "./package.json")).name
+  } catch (e) {
+    throw new Error("Invalid project root - cannot find package.json");
   }
 
   // TODO: validate options, or only persist specific values
@@ -23,12 +42,15 @@ export default function Interlock (options) {
     context: cwd,
     outputPath: path.join(cwd, "dist"),
     extensions: [".js", ".jsx", ".es6"],
-    ns: require(path.join(options.root, "./package.json")).name
+    ns: ns
   });
 }
 
+/**
+ * @return  {Promise}  Resolves to the compilation output.
+ */
 Interlock.prototype.build = function () {
-  compile(this.options)
+  return compile(this.options)
     .then(this._saveBundles)
     .catch(function (err) {
       console.log(err); // eslint-disable-line no-console
@@ -42,6 +64,7 @@ Interlock.prototype._saveBundles = function (compilation) {
     mkdirp(path.dirname(outputPath));
     fs.writeFileSync(outputPath, bundleOutput);
   }
+  return compilation;
 };
 
 function getRefreshedAsset (compilation, changedFilePath) {

--- a/spec/lib/index.spec.js
+++ b/spec/lib/index.spec.js
@@ -1,0 +1,88 @@
+/* eslint-disable max-nested-callbacks */
+
+import path from "path"
+
+import _ from "lodash";
+
+import Interlock from "../../lib/index.js";
+
+const minimalValidConfig = {
+  emit: ["./index.js"],
+  root: __dirname + "/../..",
+};
+
+describe("lib/index.js", () => {
+  describe("constructor", function () {
+    // TODO: Test for [] and undefined. _.merge ignores those values.
+    it("throws an Error if not passed invalid options", function() {
+      // Missing or empty config
+      expect(() => { new Interlock(); }).to.throw(Error);
+      expect(() => { new Interlock({}); }).to.throw(Error);
+
+      // Invalid options.emit
+      expect(() => { new Interlock(_.merge({}, minimalValidConfig, { emit: true })); }).to.throw(Error);
+      expect(() => { new Interlock(_.merge({}, minimalValidConfig, { emit: 1 })); }).to.throw(Error);
+      expect(() => { new Interlock(_.merge({}, minimalValidConfig, { emit: null })); }).to.throw(Error);
+      expect(() => {
+        var invalidConfig = _.merge({}, minimalValidConfig)
+        delete invalidConfig.emit
+        new Interlock(invalidConfig);
+      }).to.throw(Error);
+
+      // Invalid options.root
+      expect(() => { new Interlock(_.merge({}, minimalValidConfig, { root: true })); }).to.throw(Error);
+      expect(() => { new Interlock(_.merge({}, minimalValidConfig, { root: 1 })); }).to.throw(Error);
+      expect(() => { new Interlock(_.merge({}, minimalValidConfig, { root: null })); }).to.throw(Error);
+      expect(() => {
+        var invalidConfig = _.merge({}, minimalValidConfig)
+        delete invalidConfig.root
+        new Interlock(invalidConfig);
+      }).to.throw(Error);
+    });
+
+    it("fills in default values when not passed in", function() {
+      var ilk = new Interlock(minimalValidConfig);
+
+      expect(ilk.options).to.deep.equal({
+        emit: [ "./index.js" ],
+        root: __dirname + "/../..",
+        context: path.join(__dirname, "../.."),
+        outputPath: path.join(__dirname, "../..", "dist"),
+        extensions: [ ".js", ".jsx", ".es6" ],
+        ns: "interlock"
+      });
+    });
+
+    it("allows overrides to the default config", function() {
+      var ilk = new Interlock({
+        emit: ["./index.js"],
+        root: __dirname + "/../..",
+        context: "custom context",
+        outputPath: "custom outputPath",
+        extensions: [".custom"],
+        ns: "custom-namespace"
+      });
+
+      expect(ilk.options).to.deep.equal({
+        emit: [ "./index.js" ],
+        root: __dirname + "/../..",
+        context: "custom context",
+        outputPath: "custom outputPath",
+        extensions: [".custom"],
+        ns: "custom-namespace"
+      });
+    });
+  });
+
+  describe("build", function() {
+    it("return a Promise");
+    it("resolves to the compilation output");
+  });
+  describe("watch", function() {
+    it("rebuilds on file change");
+  });
+  describe("_saveBundles", function() {
+    it("saves output from compilation to outputPath");
+    it("prefixes bundles with namespace");
+  });
+});


### PR DESCRIPTION
This PR does 5 things.

1. Add super basic documentation in the entry point of Interlock
2. Add a slightly more robust test of the emit options
3. Test the _required_ root property
4. Return a Promise resolving to the compilation in `interlockInstance.build()`
5. Add a few basic tests to `./lib/index.js`