### PR TITLE
Add more complete .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,40 @@
-# added by GitSavvy
-node_modules/
+# --------------------
+# OSX Files
+# --------------------
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.Spotlight-V100
+.Trashes
 
-# added by GitSavvy
+# --------------------
+# Sublime Text Files
+# --------------------
+*.sublime-project
+*.sublime-workspace
+
+# --------------------
+# IntelliJ Files
+# --------------------
+*.iml
+*.ipr
+*.iws
+.idea/
+out/
+
+# --------------------
+# Eclipse Files
+# --------------------
+.project
+.metadata
+*.bak
+.classpath
+.settings/
+
+# --------------------
+# App Files
+# --------------------
+node_modules/
 dist/


### PR DESCRIPTION
Update .gitignore to be more friendly to developers who may not have a global gitignore to prevent commits of OSX specific files and to developers using all types of editors.

Straight from:
https://github.com/divmain/js-seed/blob/master/.gitignore