### PR TITLE
Add better docs to index.js constructor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,13 +12,18 @@ import loadAst from "./compile/modules/load-ast";
 import compileModules from "./compile/modules/compile";
 
 /**
- * @param   {Object}  options
- * @param   {Array}   options.emit
- * @param   {String}  options.root
- * @param   {String}  options.context [optional]     Interlock's working directory
- * @param   {String}  options.outputPath [optional]  An output directory
- * @param   {Array}   options.extensions [optional]  A list of filetypes for Interlock to read
- * @param   {String}  options.ns  [optional]         A custom prefix for generated bundles
+ * The entry point for the Interlock application
+ *
+ * @param   {Object}    options
+ * @param   {Object[]}  options.emit         - An Array of Objects containing compilation options for entry points
+ * @param   {String}    options.emit[].entry - The path of a JavaScript entry point (relative to options.root)
+ * @param   {String}    options.emit[].dest  - The path to output the compiled JavaScript for the specified entry point (relative to options.outputPath)
+ * @param   {String}    options.root         - The root for interlock and root for file fetching paths on the client
+ *
+ * @param   {String} [process.cwd]  options.context - Interlock's working directory
+ * @param   {String} [process.cwd + "/dist"]  options.outputPath - The root used to generate an entry point's absolute output path
+ * @param   {Array}  [[".js", ".jsx", ".es6"]]  options.extensions - A list of filetypes for Interlock to read
+ * @param   {String} [root + "/package.json".name]  options.ns - A custom prefix for generated bundles
  */
 export default function Interlock (options) {
   const cwd = process.cwd();


### PR DESCRIPTION
This PR tries to improve the JS doc around the Interlock constructor.

I'm still a bit unclear on the distinction between all the different paths so some of this might need editing. Specifically I'm not sure I understand the interplay between `options.context` `options.root` and `options.outputPath`.