### PR TITLE
Add npm-debug.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ out/
 # --------------------
 # App Files
 # --------------------
+npm-debug.log
 node_modules/
 dist/


### PR DESCRIPTION
Since all of the tasks are using npm scripts I thought it would be good to gitignore this as it will be generated with every lint/test failure.