### PR TITLE
Use cheap traversal in updateRequires

### DIFF
--- a/docs/compilation.json
+++ b/docs/compilation.json
@@ -852,7 +852,7 @@
                 ],
                 "name": "updateRequires",
                 "fnStart": 17,
-                "fnEnd": 37,
+                "fnEnd": 31,
                 "doc": "*\n * Give a module whose dependencies have been identified and compiled, replace\n * all original `require(\"path/to/dep\")` with `require(\"HASH_OF_DEP\")`.\n *\n * @param  {Object}  module  Module with AST containing original require expressions.\n *\n * @return {Object}          Module with AST containing require expressions whose\n *                           arguments have been replaced with corresponding dependency\n *                           module hashes.\n ",
                 "parsedDoc": {
                   "tags": [
@@ -881,7 +881,7 @@
                 }
               },
               "children": [],
-              "markdown": "## updateRequires\n  \nGive a module whose dependencies have been identified and compiled, replace\nall original `require(\"path/to/dep\")` with `require(\"HASH_OF_DEP\")`.\n\n  \n|     | Name | Type | Description |\n| --- | ---- | ---- | ----------- |\n| Parameter | **module** | Object | Module with AST containing original require expressions. |\n| Return value |  | Object | Module with AST containing require expressions whose arguments have been replaced with corresponding dependency module hashes. |\n\n\n  This Pluggable's definition can be found [here](http://github.com/interlockjs/interlock/tree/master/src/compile/modules/update-requires.js#L17-L37).\n\n  ",
+              "markdown": "## updateRequires\n  \nGive a module whose dependencies have been identified and compiled, replace\nall original `require(\"path/to/dep\")` with `require(\"HASH_OF_DEP\")`.\n\n  \n|     | Name | Type | Description |\n| --- | ---- | ---- | ----------- |\n| Parameter | **module** | Object | Module with AST containing original require expressions. |\n| Return value |  | Object | Module with AST containing require expressions whose arguments have been replaced with corresponding dependency module hashes. |\n\n\n  This Pluggable's definition can be found [here](http://github.com/interlockjs/interlock/tree/master/src/compile/modules/update-requires.js#L17-L31).\n\n  ",
               "size": 1
             }
           ],

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -646,5 +646,5 @@ all original `require("path/to/dep")` with `require("HASH_OF_DEP")`.
 | Return value |  | Object | Module with AST containing require expressions whose arguments have been replaced with corresponding dependency module hashes. |
 
 
-This Pluggable's definition can be found [here](http://github.com/interlockjs/interlock/tree/master/src/compile/modules/update-requires.js#L17-L37).
+This Pluggable's definition can be found [here](http://github.com/interlockjs/interlock/tree/master/src/compile/modules/update-requires.js#L17-L31).
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/interlockjs/interlock",
   "dependencies": {
     "babel-core": "^6.9.1",
-    "babel-generator": "^6.10.2",
+    "babel-generator": "6.11.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.10.3",
     "babel-polyfill": "^6.9.1",
     "babel-traverse": "^6.9.0",

--- a/src/compile/modules/update-requires.js
+++ b/src/compile/modules/update-requires.js
@@ -1,4 +1,3 @@
-import { transformFromAst } from "babel-core";
 import traverse from "babel-traverse";
 
 import { pluggable } from "pluggable";


### PR DESCRIPTION
This shaves off about ~200ms on average from the example build with `lodash`.

full traverse avg over ten builds: 2813.4 ms
cheap travers avg over ten builds: 2599.1 ms

Also pinned `babel-generator`!
